### PR TITLE
Feature/revert response parser contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,5 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+
+Collector\.Common\.RestContracts\.sln\.DotSettings

--- a/src/Collector.Common.RestContracts/Collector.Common.RestContracts.csproj
+++ b/src/Collector.Common.RestContracts/Collector.Common.RestContracts.csproj
@@ -7,7 +7,7 @@
 		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
 		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
 		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-		<Version>8.0.0</Version>
+		<Version>7.0.1</Version>
 		<Description>Base rest contracts to be used with Common RestClient and WebApi</Description>
 		<Authors>Team Heimdal, Team Houdini</Authors>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/src/Collector.Common.RestContracts/Collector.Common.RestContracts.csproj
+++ b/src/Collector.Common.RestContracts/Collector.Common.RestContracts.csproj
@@ -7,7 +7,7 @@
 		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
 		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
 		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-		<Version>7.0.0</Version>
+		<Version>8.0.0</Version>
 		<Description>Base rest contracts to be used with Common RestClient and WebApi</Description>
 		<Authors>Team Heimdal, Team Houdini</Authors>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/src/Collector.Common.RestContracts/Interfaces/ISuccessfulResponseParser.cs
+++ b/src/Collector.Common.RestContracts/Interfaces/ISuccessfulResponseParser.cs
@@ -3,8 +3,8 @@
     /// <summary>
     /// Implement this interface on your request class if you want to control how successful data objects are parsed from the raw response of the server.
     /// </summary>
-    public interface ISuccessfulResponseParser
+    public interface ISuccessfulResponseParser<out TResponse>
     {
-        TResponse ParseResponse<TResponse>(string content);
+        TResponse ParseResponse(string content);
     }
 }


### PR DESCRIPTION
We decided that the previous contract update (version 7.0.0) is not a good way forward.

This PR reverts the change in ISuccessfulResponseParser (from version 7.0.0) and bumps the major version.